### PR TITLE
docs: correct notebook name and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ pip install -r requirements.txt
 ```
 
 ### **4️⃣ Train the Model**
-Run the following script to generate the model:
+Open `Movie Recommender System Data Analysis.ipynb` in Jupyter and run all cells to generate the model.
+
+Alternatively, convert the notebook to a script and execute it:
+
 ```bash
-python Movie_Recommender_System_Data_Analysis.ipynb
+jupyter nbconvert --to script "Movie Recommender System Data Analysis.ipynb"
+python "Movie Recommender System Data Analysis.py"
 ```
 
 ### **5️⃣ Start the Streamlit App**


### PR DESCRIPTION
## Summary
- Fix README to reference `Movie Recommender System Data Analysis.ipynb` accurately
- Replace `python` call with Jupyter/nbconvert instructions for running the notebook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4e319f5c83219214840ac32c358a