### PR TITLE
Add genre and year filters to movie recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ This is a **Streamlit web application** that recommends movies based on user int
 - **Hover effects** on movie cards for a smooth experience.
 - **Optimized for both desktop & mobile viewing.**
 
+### **🗂️ 7. Genre & Year Filters**
+- Narrow recommendations using a **genre multiselect** and **release year range slider**.
+- Helps you find the perfect movie for your mood or era.
+
 ---
 
 ## 📊 Dataset Used


### PR DESCRIPTION
## Summary
- Expose genres via multiselect and release years via range slider
- Filter movie dataset and similarity matrix before generating recommendations
- Fix indexing bug in similarity matrix filtering to avoid out-of-bounds errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24c79432c832cb5b648fa57698414